### PR TITLE
Fix for Spring Boot 2.0 and Spring Cloud Stream 2.0

### DIFF
--- a/spring-cloud-starter-stream-processor-httpclient/README.adoc
+++ b/spring-cloud-starter-stream-processor-httpclient/README.adoc
@@ -37,10 +37,10 @@ The **$$httpclient$$** $$processor$$ has the following options:
 //tag::configuration-properties[]
 $$httpclient.body$$:: $$The (static) request body; if neither this nor bodyExpression is provided, the payload will be used.$$ *($$Object$$, default: `$$<none>$$`)*
 $$httpclient.body-expression$$:: $$A SpEL expression to derive the request body from the incoming message.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$httpclient.expected-response-type$$:: $$The type used to interpret the response.$$ *($$java.lang.Class<?>$$, default: `$$<none>$$`)*
+$$httpclient.expected-response-type$$:: $$The type used to interpret the response.$$ *($$Class<?>$$, default: `$$<none>$$`)*
 $$httpclient.headers-expression$$:: $$A SpEL expression used to derive the http headers map to use.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$httpclient.http-method$$:: $$The kind of http method to use.$$ *($$HttpMethod$$, default: `$$<none>$$`, possible values: `GET`,`HEAD`,`POST`,`PUT`,`PATCH`,`DELETE`,`OPTIONS`,`TRACE`)*
-$$httpclient.reply-expression$$:: $$A SpEL expression used to compute the final result, applied against the whole http response.$$ *($$Expression$$, default: `$$body$$`)*
+$$httpclient.http-method$$:: $$The kind of http method to use.$$ *($$HttpMethod)$$, default: `$$<none>$$`)*
+$$httpclient.reply-expression$$:: $$A SpEL expression used to compute the final result, applied against the whole http response.$$ *($$Expression)$$, default: `$$body$$`)*
 $$httpclient.url$$:: $$The URL to issue an http request to, as a static value.$$ *($$String$$, default: `$$<none>$$`)*
 $$httpclient.url-expression$$:: $$A SpEL expression against incoming message to determine the URL to use.$$ *($$Expression$$, default: `$$<none>$$`)*
 //end::configuration-properties[]

--- a/spring-cloud-starter-stream-processor-httpclient/src/test/java/org/springframework/cloud/stream/app/httpclient/processor/HttpClientProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-httpclient/src/test/java/org/springframework/cloud/stream/app/httpclient/processor/HttpClientProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -51,6 +51,7 @@ import java.util.Map;
  * @author Mark Fisher
  * @author Gary Russell
  * @author David Turanski
+ * @author Chris Schaefer
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -137,7 +138,8 @@ public abstract class HttpClientProcessorTests {
 		"httpclient.urlExpression='http://localhost:' + @environment.getProperty('local.server.port') +'/greet'",
 		"httpclient.httpMethod=POST",
 		"httpclient.headersExpression={Accept:'application/octet-stream'}",
-		"httpclient.expectedResponseType=byte[]"
+		"httpclient.expectedResponseType=byte[]",
+		"spring.cloud.stream.bindings.output.contentType=application/octet-stream"
 	})
 	public static class TestRequestWithReturnTypeTests extends HttpClientProcessorTests {
 
@@ -204,10 +206,11 @@ public abstract class HttpClientProcessorTests {
 	}
 
 	@SpringBootApplication
-	@EnableWebSecurity
+	@EnableAutoConfiguration(exclude = {
+			org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration.class
+	})
 	@Import(AdditionalController.class)
 	public static class HttpClientProcessorApplication {
 
 	}
-
 }


### PR DESCRIPTION
according to the boot 2.0 change log, all end points are being secured so this change disables that as security does not appear to be needed in the tests. one test needed to have the SCSt binding content type set explicitly as the expected return type is a byte[] rather than a JSON string.

other apps (python at least) have a dependency on this project so this PR may resolve other project issues.