### PR TITLE
GH-32: Add retry support into the processor

### DIFF
--- a/spring-cloud-starter-stream-processor-httpclient/README.adoc
+++ b/spring-cloud-starter-stream-processor-httpclient/README.adoc
@@ -45,6 +45,10 @@ $$httpclient.http-method-expression$$:: $$A SpEL expression to derive the reques
 $$httpclient.reply-expression$$:: $$A SpEL expression used to compute the final result, applied against the whole http response.$$ *($$Expression$$, default: `$$body$$`)*
 $$httpclient.url$$:: $$The URL to issue an http request to, as a static value.$$ *($$String$$, default: `$$<none>$$`)*
 $$httpclient.url-expression$$:: $$A SpEL expression against incoming message to determine the URL to use.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$httpclient.retry.enabled$$:: $$Whether retries are enabled around HTTP requests.$$ *($$boolean$$, default: `$$false$$`)*
+$$httpclient.retry.maxAttempts$$:: $$Maximum number of attempts to deliver a message.$$ *($$int$$, default: `$$3$$`)*
+$$httpclient.retry.initialInterval$$:: $$Duration between the first and second attempt to deliver a message.$$ *($$Duration$$, default: `$$1000ms$$`)*
+$$httpclient.retry.maxInterval$$:: $$Maximum duration between attempts.$$ *($$Duration$$, default: `$$10000ms$$`)*
 //end::configuration-properties[]
 
 == Build

--- a/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.stream.app.httpclient.processor;
 
+import java.time.Duration;
 import java.util.function.Function;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +29,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
 import org.springframework.messaging.Message;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * A processor app that makes requests to an HTTP resource and emits the
@@ -38,21 +45,44 @@ import org.springframework.messaging.Message;
  * @author Gary Russell
  * @author Christian Tzolov
  * @author David Turanski
+ * @author Artem Bilan
  */
 @Configuration
 @Import(HttpclientProcessorFunctionConfiguration.class)
 @EnableBinding(Processor.class)
-
 public class HttpclientProcessorConfiguration {
 
-	@Autowired
-	private Function<Message<?>, Object> httpRequest;
+	@Bean
+	IntegrationFlow httpClientFlow(Processor processor, Function<Message<?>, Object> httpRequest,
+			ObjectProvider<RequestHandlerRetryAdvice> requestHandlerRetryAdvice) {
+		return IntegrationFlows
+				.from(processor.input())
+				.transform(Message.class, httpRequest::apply, (e) -> requestHandlerRetryAdvice.ifAvailable(e::advice))
+				.channel(processor.output()).get();
+	}
 
 	@Bean
-	IntegrationFlow httpClientflow(Processor processor) {
-		return IntegrationFlows
-			.from(processor.input())
-			.transform(Message.class, httpRequest::apply)
-			.channel(processor.output()).get();
+	@ConditionalOnProperty(prefix = "httpclient.retry", name = "enabled")
+	RequestHandlerRetryAdvice requestHandlerRetryAdvice(HttpclientProcessorProperties processorProperties) {
+		RequestHandlerRetryAdvice requestHandlerRetryAdvice = new RequestHandlerRetryAdvice();
+		requestHandlerRetryAdvice.setRetryTemplate(createRetryTemplate(processorProperties.getRetry()));
+		return requestHandlerRetryAdvice;
 	}
+
+	private RetryTemplate createRetryTemplate(HttpclientProcessorProperties.Retry properties) {
+		PropertyMapper map = PropertyMapper.get();
+		RetryTemplate template = new RetryTemplate();
+		SimpleRetryPolicy policy = new SimpleRetryPolicy();
+		map.from(properties::getMaxAttempts).to(policy::setMaxAttempts);
+		template.setRetryPolicy(policy);
+		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+		map.from(properties::getInitialInterval).whenNonNull().as(Duration::toMillis)
+				.to(backOffPolicy::setInitialInterval);
+		map.from(properties::getMultiplier).to(backOffPolicy::setMultiplier);
+		map.from(properties::getMaxInterval).whenNonNull().as(Duration::toMillis)
+				.to(backOffPolicy::setMaxInterval);
+		template.setBackOffPolicy(backOffPolicy);
+		return template;
+	}
+
 }

--- a/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-httpclient/src/main/java/org/springframework/cloud/stream/app/httpclient/processor/HttpclientProcessorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.stream.app.httpclient.processor;
 
+import java.time.Duration;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -23,15 +28,13 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.http.HttpMethod;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.NotNull;
-
 /**
  * Configuration properties for the Http Client Processor module.
  *
  * @author Waldemar Hummer
  * @author Mark Fisher
  * @author Christian Tzolov
+ * @author Artem Bilan
  */
 @ConfigurationProperties("httpclient")
 @Validated
@@ -86,6 +89,8 @@ public class HttpclientProcessorProperties {
 	 * A SpEL expression used to compute the final result, applied against the whole http response.
 	 */
 	private Expression replyExpression = new SpelExpressionParser().parseExpression("body");
+
+	private final Retry retry = new Retry();
 
 	public void setUrl(String url) {
 		this.url = url;
@@ -163,6 +168,10 @@ public class HttpclientProcessorProperties {
 		this.replyExpression = replyExpression;
 	}
 
+	public Retry getRetry() {
+		return this.retry;
+	}
+
 	@AssertTrue(message = "Exactly one of 'url' or 'urlExpression' is required")
 	public boolean isExactlyOneUrl() {
 		return url == null ^ urlExpression == null;
@@ -171,6 +180,76 @@ public class HttpclientProcessorProperties {
 	@AssertTrue(message = "At most one of 'body' or 'bodyExpression' is allowed")
 	public boolean isAtMostOneBody() {
 		return body == null || bodyExpression == null;
+	}
+
+
+	public static class Retry {
+
+		/**
+		 * Whether retries are enabled around HTTP requests.
+		 */
+		private boolean enabled;
+
+		/**
+		 * Maximum number of attempts to deliver a message.
+		 */
+		private int maxAttempts = 3;
+
+		/**
+		 * Duration between the first and second attempt to deliver a message.
+		 */
+		private Duration initialInterval = Duration.ofMillis(1000);
+
+		/**
+		 * Multiplier to apply to the previous retry interval.
+		 */
+		private double multiplier = 1.0;
+
+		/**
+		 * Maximum duration between attempts.
+		 */
+		private Duration maxInterval = Duration.ofMillis(10000);
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public int getMaxAttempts() {
+			return this.maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
+		public Duration getInitialInterval() {
+			return this.initialInterval;
+		}
+
+		public void setInitialInterval(Duration initialInterval) {
+			this.initialInterval = initialInterval;
+		}
+
+		public double getMultiplier() {
+			return this.multiplier;
+		}
+
+		public void setMultiplier(double multiplier) {
+			this.multiplier = multiplier;
+		}
+
+		public Duration getMaxInterval() {
+			return this.maxInterval;
+		}
+
+		public void setMaxInterval(Duration maxInterval) {
+			this.maxInterval = maxInterval;
+		}
+
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-cloud-stream-app-starters/httpclient/issues/32

* Introduce a `HttpclientProcessorProperties.Retry` configuration
options
* Apply `Retry` options to the internal `RetryTemplate` and use it in
the conditional `RequestHandlerRetryAdvice` bean which is applied to
the endpoint of the `.transform()` in the `httpClientFlow` definition
* Verify in the `HttpClientProcessorTests.TestRequestWithMethodExpressionTests`
that provided retry options are applied and `RequestHandlerRetryAdvice`
is populated into an appropriate endpoint